### PR TITLE
INTERLOK-3381 Remove Deprecated members of JsonToFixedCSV

### DIFF
--- a/src/main/java/com/adaptris/core/transform/csvjson/JsonToFixedCSV.java
+++ b/src/main/java/com/adaptris/core/transform/csvjson/JsonToFixedCSV.java
@@ -6,25 +6,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.supercsv.io.CsvListWriter;
 import com.adaptris.annotation.AdapterComponent;
-import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.json.JsonUtil;
 import com.adaptris.core.services.splitter.LineCountSplitter;
-import com.adaptris.core.services.splitter.MessageSplitterImp;
 import com.adaptris.core.services.splitter.json.JsonArraySplitter;
 import com.adaptris.core.services.splitter.json.JsonObjectSplitter;
 import com.adaptris.core.services.splitter.json.JsonProvider.JsonObjectProvider;
@@ -33,7 +26,6 @@ import com.adaptris.core.services.splitter.json.LargeJsonArraySplitter;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.CloseableIterable;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.core.util.LoggingHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -77,29 +69,6 @@ public class JsonToFixedCSV extends JsonArrayToCSV {
   @Setter
   private String csvHeader = "";
 
-  /**
-   * Whether or not to emit the header in the resulting document.
-   * 
-   */
-  @Valid
-  @InputFieldDefault(value = "true")
-  @Getter
-  @Setter
-  @Deprecated
-  @Removal(version = "3.11", message = "use include-header instead")
-  private Boolean showHeader;
-
-  /**
-   * The splitter used to generate each CSV row.
-   */
-  @Valid
-  @Getter
-  @Setter
-  @AdvancedConfig(rare = true)
-  @Deprecated
-  @Removal(version = "3.11.0", message = "Use JsonStyle instead")
-  private MessageSplitterImp messageSplitter = null;
-
   public JsonToFixedCSV(String hdrs) {
     this();
     setCsvHeader(hdrs);
@@ -107,13 +76,6 @@ public class JsonToFixedCSV extends JsonArrayToCSV {
   
   @Override
   protected boolean includeHeader(AdaptrisMessage msg) {
-    if (getShowHeader() != null) {
-      LoggingHelper.logWarning(headerWarning, () -> {
-        headerWarning = true;
-      }, "show-headers is deprecated, use include-header instead");
-      return BooleanUtils.toBooleanDefaultIfNull(getShowHeader(), true);
-
-    }
     return super.includeHeader(msg);
   }
 
@@ -194,21 +156,6 @@ public class JsonToFixedCSV extends JsonArrayToCSV {
   // interface
   @Override
   protected JsonObjectProvider jsonStyle() {
-    if (getMessageSplitter() != null) {
-      LoggingHelper.logWarning(splitterWarning, () -> {
-        splitterWarning = true;
-      }, "message-splitter is deprecated, use a JsonStyle instead");
-      JsonObjectProvider style = SPLITTER_STYLE.get(getMessageSplitter().getClass());
-      // Might be a LargeJsonArrayPathSplitter (crazy talk if you ask me).
-      if (style == null) {
-        style = (msg) -> {
-          MessageSplitterImp imp = getMessageSplitter();
-          imp.setMessageFactory(AdaptrisMessageFactory.getDefaultInstance());
-          return CloseableIterable.ensureCloseable(imp.splitMessage(msg));
-        };
-      }
-      return Args.notNull(style, "json style");
-    }
     return ObjectUtils.defaultIfNull(getJsonStyle(), JsonStyle.JSON_ARRAY);
   }
 

--- a/src/main/java/com/adaptris/core/transform/csvjson/JsonToFixedCSV.java
+++ b/src/main/java/com/adaptris/core/transform/csvjson/JsonToFixedCSV.java
@@ -2,7 +2,6 @@ package com.adaptris.core.transform.csvjson;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,12 +16,8 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.json.JsonUtil;
-import com.adaptris.core.services.splitter.LineCountSplitter;
-import com.adaptris.core.services.splitter.json.JsonArraySplitter;
-import com.adaptris.core.services.splitter.json.JsonObjectSplitter;
 import com.adaptris.core.services.splitter.json.JsonProvider.JsonObjectProvider;
 import com.adaptris.core.services.splitter.json.JsonProvider.JsonStyle;
-import com.adaptris.core.services.splitter.json.LargeJsonArraySplitter;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.CloseableIterable;
 import com.adaptris.core.util.ExceptionHelper;
@@ -43,21 +38,6 @@ import lombok.Setter;
 @DisplayOrder(order = {"csvHeader", "includeHeader", "jsonStyle", "preferenceBuilder"})
 @NoArgsConstructor
 public class JsonToFixedCSV extends JsonArrayToCSV {
-
-  private transient boolean headerWarning = false;
-  private transient boolean splitterWarning = false;
-
-  private static final Map<Class, JsonStyle> SPLITTER_STYLE;
-
-  static {
-    // Map the supported splitters into the various possible styles.
-    Map<Class, JsonStyle> map = new HashMap<>();
-    map.put(JsonArraySplitter.class, JsonStyle.JSON_ARRAY);
-    map.put(LargeJsonArraySplitter.class, JsonStyle.JSON_ARRAY);
-    map.put(JsonObjectSplitter.class, JsonStyle.JSON_OBJECT);
-    map.put(LineCountSplitter.class, JsonStyle.JSON_LINES);
-    SPLITTER_STYLE = Collections.unmodifiableMap(map);
-  }
 
   /**
    * The CSV Header.

--- a/src/test/java/com/adaptris/core/transform/csvjson/JsonToFixedCSVTest.java
+++ b/src/test/java/com/adaptris/core/transform/csvjson/JsonToFixedCSVTest.java
@@ -12,12 +12,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceCase;
-import com.adaptris.core.common.ConstantDataInputParameter;
-import com.adaptris.core.services.splitter.json.JsonArraySplitter;
-import com.adaptris.core.services.splitter.json.JsonObjectSplitter;
-import com.adaptris.core.services.splitter.json.JsonPathSplitter;
 import com.adaptris.core.services.splitter.json.JsonProvider.JsonStyle;
-import com.adaptris.core.services.splitter.json.LargeJsonArraySplitter;
 import com.adaptris.csv.BasicPreferenceBuilder;
 import com.adaptris.csv.BasicPreferenceBuilder.Style;
 
@@ -49,22 +44,6 @@ public class JsonToFixedCSVTest extends ServiceCase {
     return true;
   }
 
-  /**
-   * Test that a JSON array becomes several lines on CSV, and displaying CSV header column names.
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testArrayWithHeader_WithSplitter() throws Exception {
-    AdaptrisMessage message = getMessage(JSON_ARRAY);
-    JsonToFixedCSV service = buildService(true, CSV_HEADER);
-    service.setMessageSplitter(new LargeJsonArraySplitter());
-
-    execute(service, message);
-
-    Assert.assertEquals(LargeJsonArraySplitter.class, service.getMessageSplitter().getClass());
-    Assert.assertEquals(asList(CSV_ARRAY_HEADER), listify(message.getInputStream()));
-  }
 
   @Test
   public void testArrayWithHeader() throws Exception {
@@ -91,17 +70,6 @@ public class JsonToFixedCSVTest extends ServiceCase {
     Assert.assertEquals(asList(CSV_ARRAY), listify(message.getInputStream()));
   }
 
-  @Test
-  public void testArrayNoHeader_WithSplitter() throws Exception {
-    AdaptrisMessage message = getMessage(JSON_ARRAY);
-    JsonToFixedCSV service = buildService(false, CSV_HEADER);
-    service.setMessageSplitter(new JsonArraySplitter());
-
-    execute(service, message);
-
-    Assert.assertEquals(asList(CSV_ARRAY), listify(message.getInputStream()));
-  }
-
 
   /**
    * Test that a JSON object becomes CSV data, and displaying CSV header column names.
@@ -118,17 +86,6 @@ public class JsonToFixedCSVTest extends ServiceCase {
     execute(service, message);
 
     System.err.println(message.getContent());
-    Assert.assertEquals(asList(CSV_OBJECT_HEADER), listify(message.getInputStream()));
-  }
-
-  @Test
-  public void testObjectWithHeader_WithSplitter() throws Exception {
-    AdaptrisMessage message = getMessage(JSON_OBJECT);
-    JsonToFixedCSV service = buildService(true, CSV_HEADER);
-    service.setMessageSplitter(new JsonObjectSplitter());
-
-    execute(service, message);
-
     Assert.assertEquals(asList(CSV_OBJECT_HEADER), listify(message.getInputStream()));
   }
 
@@ -156,20 +113,6 @@ public class JsonToFixedCSVTest extends ServiceCase {
         .withJsonStyle(JsonStyle.JSON_LINES);
     execute(service, message);
     Assert.assertEquals(asList(CSV_JSON_LINES), listify(message.getInputStream()));
-  }
-
-  @Test
-  // Special case with an "unsupported splitter"...
-  public void testJsonArrayPath() throws Exception {
-    AdaptrisMessage message = getMessage(JSON_ARRAY_PATH);
-    JsonToFixedCSV service = buildService(true, CSV_HEADER);
-    JsonPathSplitter splitter = new JsonPathSplitter();
-    splitter.setJsonPath(new ConstantDataInputParameter(JSON_ARRAY_PATH_JSONPATH));
-    service.setMessageSplitter(splitter);
-
-    execute(service, message);
-
-    Assert.assertEquals(asList(CSV_JSON_ARRAY_PATH), listify(message.getInputStream()));
   }
 
   /**
@@ -212,7 +155,7 @@ public class JsonToFixedCSVTest extends ServiceCase {
 
   private JsonToFixedCSV buildService(boolean showHeader, String header) {
     JsonToFixedCSV service = new JsonToFixedCSV();
-    service.setShowHeader(showHeader);
+    service.setIncludeHeader(String.valueOf(showHeader));
     service.setCsvHeader(header);
     return service;
   }


### PR DESCRIPTION
## Motivation

Remove items marked for removal in 3.11.0

## Modification

Removed the `message-splitter` member from json-to-fixed-csv

## Result

1 edge use-case is now broken, which is if you have configured a json-path-splitter (i.e. you want to turn JSON into CSV but first you want to do kind of json-path on it first...) -> this is pretty theoretical edge case and could be handled with a

- SplitJoinService (splitter=JsonPathSplitter) -> json-to-fixed-csv (json-object) -> csv-aggregator; 

