### PR TITLE
INTERLOK-3426 Support for json-lines

### DIFF
--- a/src/main/java/com/adaptris/core/transform/csvjson/CSVToJson.java
+++ b/src/main/java/com/adaptris/core/transform/csvjson/CSVToJson.java
@@ -1,0 +1,121 @@
+package com.adaptris.core.transform.csvjson;
+
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.csv.PreferenceBuilder;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Transform a CSV document into a JSON object of some description.
+ *
+ * <p>
+ * Takes a CSV document and renders as it as JSON, either a standard JSON Array or a
+ * <a href="http://jsonlines.org">jsonlines</a>.
+ * </p>
+ * <p>
+ * If our input document is
+ *
+ * <pre>
+ * {@code
+ * firstname, lastname, dob
+ * "alice","smith", "2017-01-01"
+ * "bob", "smith", "2017-01-02"
+ * "carol","smith", "2017-01-03"
+ * }
+ * </pre>
+ *
+ * then selecting JSON_ARRAY will effectively render as
+ *
+ * <pre>
+ * {@code
+ * [
+ *   { "firstname":"alice", "lastname":"smith", "dob":"2017-01-01" },
+ *   { "firstname":"bob", "lastname":"smith", "dob":"2017-01-02" },
+ *   { "firstname":"carol", "lastname":"smith", "dob":"2017-01-03" }
+ * ]}
+ * </pre>
+ *
+ * Selecting JSON_LINES will effectively render as
+ *
+ * <pre>
+ * {@code
+ * { "firstname":"alice", "lastname":"smith", "dob":"2017-01-01" }
+ * { "firstname":"bob", "lastname":"smith", "dob":"2017-01-02" }
+ * { "firstname":"carol", "lastname":"smith", "dob":"2017-01-03" }
+ * }
+ * </pre>
+ * </p>
+ *
+ * @config csv-to-json
+ */
+@AdapterComponent
+@ComponentProfile(summary = "Transfrom CSV into JSON", tag = "service,csv,json")
+@XStreamAlias("csv-to-json")
+@NoArgsConstructor
+public class CSVToJson extends CSVConverter {
+
+  public static enum OutputStyle {
+    JSON_ARRAY {
+      @Override
+      public CsvJsonTransformer build(PreferenceBuilder b) {
+        return new CsvJsonArrayTransformer(b);
+      }
+    },
+    JSON_LINES {
+      @Override
+      public CsvJsonTransformer build(PreferenceBuilder b) {
+        return new CsvJsonLinesTransformer(b);
+      }
+
+    };
+
+    public abstract CsvJsonTransformer build(PreferenceBuilder b);
+  }
+
+  @Getter(AccessLevel.PRIVATE)
+  @Setter(AccessLevel.PRIVATE)
+  private transient CsvJsonTransformer transformer;
+
+
+  /**
+   * The JSON output style.
+   * <p>
+   * The default if not specified is {@code JSON_ARRAY} for backwards compatibility reasons.
+   * </p>
+   */
+  @InputFieldDefault(value = "JSON_ARRAY")
+  @Getter
+  @Setter
+  private OutputStyle style;
+
+  @Override
+  public void prepare() throws CoreException {
+    super.prepare();
+    setTransformer(style().build(getPreferenceBuilder()));
+  }
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
+    getTransformer().transform(msg);
+  }
+
+  private OutputStyle style() {
+    return ObjectUtils.defaultIfNull(getStyle(), OutputStyle.JSON_ARRAY);
+  }
+
+  public CSVToJson withStyle(OutputStyle s) {
+    setStyle(s);
+    return this;
+  }
+}

--- a/src/main/java/com/adaptris/core/transform/csvjson/CSVToJsonArray.java
+++ b/src/main/java/com/adaptris/core/transform/csvjson/CSVToJsonArray.java
@@ -1,94 +1,32 @@
 package com.adaptris.core.transform.csvjson;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Writer;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import org.supercsv.io.CsvMapReader;
-import org.supercsv.prefs.CsvPreference;
-import org.supercsv.util.Util;
-import com.adaptris.annotation.AdapterComponent;
-import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.util.Args;
-import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LoggingHelper;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import lombok.NoArgsConstructor;
 
 /**
  * Transform a CSV document into a JSON Array.
  * 
- * <p>
- * Takes a CSV document and renders as it as JSON:
- * <pre>
- * {@code
- * firstname, lastname, dob
- * "alice","smith", "2017-01-01"
- * "bob", "smith", "2017-01-02"
- * "carol","smith", "2017-01-03"
- * }
- * </pre>
- * will effectively render as
- * <pre>
- * {@code 
- * [
- *   { "firstname":"alice", "lastname":"smith", "dob":"2017-01-01" },
- *   { "firstname":"bob", "lastname":"smith", "dob":"2017-01-02" },
- *   { "firstname":"carol", "lastname":"smith", "dob":"2017-01-03" }
- * ]}
- * </pre>
- * </p>
- * 
- * @config csv-to-json
- *
+ * @deprecated since 3.11.1 poorly named class since we support json-lines as well, so use
+ *             {@link CSVToJson} instead.
  */
-@AdapterComponent
-@ComponentProfile(summary = "Transfrom CSV into JSON", tag = "service,csv,json")
-@XStreamAlias("csv-to-json")
-@NoArgsConstructor
+@Deprecated
+@Removal(version = "4.0.0")
 public class CSVToJsonArray extends CSVConverter {
 
+  private transient boolean warningLogged = false;
+
+  @Override
+  public void prepare() throws CoreException {
+    LoggingHelper.logWarning(warningLogged, () -> warningLogged = true,
+        "{} is deprecated use 'csv-json' with JSON_ARRAY instead",
+        this.getClass().getCanonicalName());
+  }
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-    log.trace("Beginning doService in {}", LoggingHelper.friendlyName(this));
-    ObjectMapper mapper = new ObjectMapper();
-    try (Reader reader = msg.getReader();
-        CsvMapReader csvReader = new PredictableMapReader(reader, getPreferenceBuilder().build());
-        Writer w = msg.getWriter();
-        JsonGenerator generator = mapper.getFactory().createGenerator(w).useDefaultPrettyPrinter()) {
-      String[] hdrs = csvReader.getHeader(true);
-      generator.writeStartArray();
-      for (Map<String, String> row; (row = csvReader.read(hdrs)) != null;) {
-        generator.writeObject(row);
-      }
-      generator.writeEndArray();;
-    } catch (Exception e) {
-      throw ExceptionHelper.wrapServiceException(e);
-    } finally {
-    }
-  }
-
-  // Copy of CsvMapReader but use LinkedHashMap for predictable iteration.
-  private class PredictableMapReader extends CsvMapReader {
-    public PredictableMapReader(final Reader reader, final CsvPreference preferences) {
-      super(reader, preferences);
-    }
-
-    @Override
-    public Map<String, String> read(final String... nameMapping) throws IOException {
-      Args.notNull(nameMapping, "mappings");
-      if (readRow()) {
-        final Map<String, String> destination = new LinkedHashMap<String, String>();
-        Util.filterListToMap(destination, nameMapping, getColumns());
-        return destination;
-      }
-      return null; // EOF
-    }
+    new CsvJsonArrayTransformer(getPreferenceBuilder()).transform(msg);
   }
 }

--- a/src/main/java/com/adaptris/core/transform/csvjson/CsvJsonArrayTransformer.java
+++ b/src/main/java/com/adaptris/core/transform/csvjson/CsvJsonArrayTransformer.java
@@ -1,0 +1,44 @@
+package com.adaptris.core.transform.csvjson;
+
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Map;
+import org.supercsv.io.CsvMapReader;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.csv.OrderedCsvMapReader;
+import com.adaptris.csv.PreferenceBuilder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class CsvJsonArrayTransformer implements CsvJsonTransformer {
+
+  @Getter(AccessLevel.PRIVATE)
+  private transient PreferenceBuilder preferenceBuilder;
+
+  @Override
+  public void transform(AdaptrisMessage msg) throws ServiceException {
+    ObjectMapper mapper = new ObjectMapper();
+    try (Reader reader = msg.getReader();
+        CsvMapReader csvReader = new OrderedCsvMapReader(reader, getPreferenceBuilder().build());
+        Writer w = msg.getWriter();
+        JsonGenerator generator =
+            mapper.getFactory().createGenerator(w).useDefaultPrettyPrinter()) {
+      String[] hdrs = csvReader.getHeader(true);
+      generator.writeStartArray();
+      for (Map<String, String> row; (row = csvReader.read(hdrs)) != null;) {
+        generator.writeObject(row);
+      }
+      generator.writeEndArray();;
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+}

--- a/src/main/java/com/adaptris/core/transform/csvjson/CsvJsonLinesTransformer.java
+++ b/src/main/java/com/adaptris/core/transform/csvjson/CsvJsonLinesTransformer.java
@@ -1,0 +1,41 @@
+package com.adaptris.core.transform.csvjson;
+
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.util.Map;
+import org.supercsv.io.CsvMapReader;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.csv.OrderedCsvMapReader;
+import com.adaptris.csv.PreferenceBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+@Slf4j
+public class CsvJsonLinesTransformer implements CsvJsonTransformer {
+
+  @Getter(AccessLevel.PRIVATE)
+  private transient PreferenceBuilder preferenceBuilder;
+
+  @Override
+  public void transform(AdaptrisMessage msg) throws ServiceException {
+    ObjectMapper mapper = new ObjectMapper();
+    try (Reader reader = msg.getReader();
+        CsvMapReader csvReader = new OrderedCsvMapReader(reader, getPreferenceBuilder().build());
+        PrintWriter pw = new PrintWriter(msg.getWriter());) {
+      String[] hdrs = csvReader.getHeader(true);
+      for (Map<String, String> row; (row = csvReader.read(hdrs)) != null;) {
+        String json = mapper.writeValueAsString(row);
+        pw.println(json);
+      }
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    }
+  }
+}
+

--- a/src/main/java/com/adaptris/core/transform/csvjson/CsvJsonTransformer.java
+++ b/src/main/java/com/adaptris/core/transform/csvjson/CsvJsonTransformer.java
@@ -1,0 +1,10 @@
+package com.adaptris.core.transform.csvjson;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ServiceException;
+
+public interface CsvJsonTransformer {
+
+  void transform(AdaptrisMessage msg) throws ServiceException;
+
+}

--- a/src/test/java/com/adaptris/core/transform/csvjson/CSVToJsonArrayTest.java
+++ b/src/test/java/com/adaptris/core/transform/csvjson/CSVToJsonArrayTest.java
@@ -9,6 +9,7 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.jayway.jsonpath.ReadContext;
 
+@SuppressWarnings("deprecation")
 public class CSVToJsonArrayTest extends CsvBaseCase {
   @Override
   public boolean isAnnotatedForJunit4() {

--- a/src/test/java/com/adaptris/core/transform/csvjson/CSVToJsonTest.java
+++ b/src/test/java/com/adaptris/core/transform/csvjson/CSVToJsonTest.java
@@ -1,0 +1,105 @@
+package com.adaptris.core.transform.csvjson;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.services.splitter.LineCountSplitter;
+import com.adaptris.core.transform.csvjson.CSVToJson.OutputStyle;
+import com.adaptris.interlok.util.CloseableIterable;
+import com.jayway.jsonpath.ReadContext;
+
+public class CSVToJsonTest extends CsvBaseCase {
+  @Override
+  public boolean isAnnotatedForJunit4() {
+    return true;
+  }
+
+  @Test
+  public void testService_Lines() throws Exception {
+    CSVToJson service = createForTests().withStyle(OutputStyle.JSON_LINES);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    execute(service, msg);
+    assertNotNull(msg.getContent());
+    LineCountSplitter splitter = new LineCountSplitter(1);
+    Collection c = collect(splitter.splitMessage(msg));
+    assertEquals(3, c.size());
+  }
+
+  @Test
+  public void testBrokenInput_Lines() throws Exception {
+    CSVToJson service = createForTests().withStyle(OutputStyle.JSON_LINES);
+    AdaptrisMessage msg = new BrokenMessageFactory(WhenToBreak.INPUT).newMessage(CSV_INPUT);
+    try {
+      execute(service, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+  @Test
+  public void testService_Array() throws Exception {
+    CSVToJson service = createForTests().withStyle(OutputStyle.JSON_ARRAY);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(CSV_INPUT);
+    execute(service, msg);
+    assertNotNull(msg.getContent());
+    System.err.println(msg.getContent());
+    ReadContext ctx = parse(msg);
+    assertEquals("alice", ctx.read("$[0].firstname"));
+    assertEquals("bob", ctx.read("$[1].firstname"));
+    assertEquals("carol", ctx.read("$[2].firstname"));
+  }
+
+
+  @Test
+  public void testBrokenInput_Array() throws Exception {
+    CSVToJson service = createForTests().withStyle(OutputStyle.JSON_ARRAY);
+    AdaptrisMessage msg = new BrokenMessageFactory(WhenToBreak.INPUT).newMessage(CSV_INPUT);
+    try {
+      execute(service, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+  @Test
+  public void testBrokenOutput_Array() throws Exception {
+    CSVToJson service = createForTests();
+    AdaptrisMessage msg = new BrokenMessageFactory(WhenToBreak.OUTPUT).newMessage(CSV_INPUT);
+    try {
+      execute(service, msg);
+      fail();
+    } catch (ServiceException expected) {
+
+    }
+  }
+
+  @Override
+  protected CSVToJson createForTests() {
+    return new CSVToJson().withStyle(CSVToJson.OutputStyle.JSON_ARRAY);
+  }
+
+  private static Collection<AdaptrisMessage> collect(Iterable<AdaptrisMessage> iter)
+      throws IOException, CoreException {
+    if (iter instanceof Collection) {
+      return (Collection<AdaptrisMessage>) iter;
+    }
+    List<AdaptrisMessage> result = new ArrayList<AdaptrisMessage>();
+    try (CloseableIterable<AdaptrisMessage> messages = CloseableIterable.ensureCloseable(iter)) {
+      for (AdaptrisMessage msg : messages) {
+        result.add(msg);
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Motivation

When turning a CSV file into JSON, you only have the option of doing a JSON_ARRAY.
Since JSON_LINES is a thing; we should also support that.

## Modification

- Deprecate CSVToJsonArray (and remove the xstream alias)
- Add pluggable implementation into csv-to-json that supports both JSON_ARRAY and JSON_LINES. The default is JSON_ARRAY for backwards compatibility since it reuses the xstream alias from CSVToJsonArray.

Note that XStream treats `-array` as special, so you can't have an xstream alias like `csv-to-json-array`

## Result

Users that directly refer to the class name in configuration will get a WARN during prepare
Users that refer to the alias will get the default backwards compat behaviour (JSON_ARRAY)
Users can now select JSON_LINES as an output.

## Testing

Do a CSV to json_lines transformation...

